### PR TITLE
Repack dependencies into validator exe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,10 +27,22 @@ jobs:
           key: nuget-packref-modules-${{ hashFiles('**/*.csproj') }}
       - name: Restore, build, and test
         run: msbuild -r -p:configuration=Debug
-      - name: Upload artifact
+      - name: Smoke test the validator outside the build dir
+        run: |
+          cp _build/KSPMMCfgValidator/Debug/bin/net461/KSPMMCfgValidator.exe .
+          chmod a+x KSPMMCfgValidator.exe
+          mono ./KSPMMCfgValidator.exe
+      - name: Upload parser nupkg artifact
         uses: actions/upload-artifact@v2
         with:
           name: KSPMMCfgParser.nupkg
-          path: _build/out/KSPMMCfgParser/Debug/bin/KSPMMCfgParser.*.nupkg
+          path: _build/KSPMMCfgParser/Debug/bin/KSPMMCfgParser.*.nupkg
+          retention-days: 7
+        if: github.event_name == 'pull_request'
+      - name: Upload validator exe artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: KSPMMCfgValidator.exe
+          path: _build/KSPMMCfgValidator/Debug/bin/net461/KSPMMCfgValidator.exe
           retention-days: 7
         if: github.event_name == 'pull_request'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ jobs:
         uses: actions/checkout@v2
       - name: Restore, build, and test
         run: msbuild -r -p:configuration=Release
+      - name: Smoke test the validator outside the build dir
+        run: |
+          cp _build/KSPMMCfgValidator/Debug/bin/net461/KSPMMCfgValidator.exe .
+          chmod a+x KSPMMCfgValidator.exe
+          mono ./KSPMMCfgValidator.exe
       - name: Get release data
         id: release_data
         run: |

--- a/KSPMMCfgValidator/KSPMMCfgValidator.csproj
+++ b/KSPMMCfgValidator/KSPMMCfgValidator.csproj
@@ -32,7 +32,25 @@
     <PackageReference Include="log4net" Version="2.0.10" />
     <PackageReference Include="ParsecSharp" Version="3.4.0"
                       PrivateAssets="All" />
+    <PackageReference Include="ILRepack" Version="2.0.18" />
+    <PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13"
+                      PrivateAssets="All"/>
     <ProjectReference Include="..\KSPMMCfgParser\KSPMMCfgParser.csproj" />
   </ItemGroup>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+  <Target Name="ILRepack" AfterTargets="Build" DependsOnTargets="Build">
+    <ItemGroup>
+      <InputAssemblies Include="log4net.dll" />
+      <InputAssemblies Include="CommandLine.dll" />
+      <InputAssemblies Include="ParsecSharp.dll" />
+      <InputAssemblies Include="KSPMMCfgParser.dll" />
+    </ItemGroup>
+    <ILRepack OutputAssembly="$(AssemblyName).exe"
+              MainAssembly="$(AssemblyName).exe"
+              InputAssemblies="@(InputAssemblies)"
+              OutputType="$(OutputType)"
+              WorkingDirectory="$(OutputPath)"
+              Internalize="true"
+              Parallel="true" />
+  </Target>
 </Project>


### PR DESCRIPTION
## Problem

@siimav has begun testing the validator action:

https://github.com/KSP-RO/RealismOverhaul/commit/746c859f2e0b076fe3eb7089224c28499c706811

And gotten some errors:

https://github.com/KSP-RO/RealismOverhaul/runs/6212192069?check_suite_focus=true

![image](https://user-images.githubusercontent.com/1559108/165774546-a08bb35b-4d72-465a-b219-41ca082abfad.png)

## Cause

`log4net.dll` is needed at runtime and missing from the Docker image. (The same is true for `CommandLine.dll`, `ParsecSharp.dll`, and `KSPMMCfgParser.dll`.)

During development, I tested the validator by running it from its build directory, which hid this problem because `msbuild` copies dependencies to that directory by default. Now I've copied just the `.exe` file by itself to another directory to make sure it works standalone.

## Changes

- Now the validator's `.csproj` file references `ILRepack` and `ILRepack.MSBuild.Task`, which it uses to repack the dependency DLLs into the validator's `.exe` file
- The GitHub workflow for pull requests is updated to use the correct path to the `.nupkg` file
- The GitHub workflow for pull requests now publishes the validator exe as an artifact
- The GitHub workflows now include a smoke test outside the build dir to catch any future dependencies that might be added
