### PR TITLE
Include file position info in message for GitHub

### DIFF
--- a/KSPMMCfgValidator/KSPMMCfgValidator.cs
+++ b/KSPMMCfgValidator/KSPMMCfgValidator.cs
@@ -85,7 +85,7 @@ namespace KSPMMCfgValidator
                          .All(v => v != null);
 
         private static readonly string errorFormat =
-            inGitHub ? "::error file={0},line={1},col={2}::{3}"
+            inGitHub ? "::error file={0},line={1},col={2}::{0}:{1}:{2}: {3}"
                      : "{0}:{1}:{2}: {3}";
 
         private const int ExitOk     = 0;


### PR DESCRIPTION
## Problem

The validator now runs after #1! This output is better than nothing, but it doesn't help much with working on fixes because you can't tell where the problem was:

![image](https://user-images.githubusercontent.com/1559108/165788999-cb79ebba-cb23-4275-b4d8-17070684a4a5.png)

## Cause

We print the filename, line, and column info, but only in the GitHub Actions output format. This allows the workflow framework to pin the errors to the exact context in which they occur:

![image](https://user-images.githubusercontent.com/1559108/165788356-a4357b4a-3282-47a4-a653-d7ed7d5e8bbd.png)

However, those links don't work if you haven't edited the affected files, and in other places the context isn't shown at all. In effect there is a distinction between "new" errors that you create in the same pull request, which GitHub handles very well, and "old" errors predating your changes that it makes hard to find.

My model for the validator has been `yamllint` since it auto-detects when it's running in an Action, and it works the same way:

![image](https://user-images.githubusercontent.com/1559108/165789488-5d52f51f-6e53-4f4b-8632-40db8bfb310a.png)

However, for our purposes, it's probably worth it to duplicate the context info to help with onboarding new projects. Maybe in the future once users have established a baseline of "clean" cfg files and gotten tired of seeing the extra info, we might change this back.

## Changes

Now the filename, line, and column are included in the error message text as well.
