### PR TITLE
Allow slashes and spaces in property identifiers

### DIFF
--- a/Tests/Parser.Property.cs
+++ b/Tests/Parser.Property.cs
@@ -43,6 +43,41 @@ namespace Tests
         }
 
         [Test]
+        public void PropertyParse_WeirdIdentifier_Works()
+        {
+            Property.Parse("CST-100 Heat Shield = heatshieldsLunar, capsulesCST")
+                    .WillSucceed(v =>
+                    {
+                        Assert.AreEqual("CST-100 Heat Shield", v.Name);
+                        Assert.AreEqual("heatshieldsLunar, capsulesCST", v.Value);
+                    });
+            Property.Parse("CST-100 Service Module = capsulesCST")
+                    .WillSucceed(v =>
+                    {
+                        Assert.AreEqual("CST-100 Service Module", v.Name);
+                        Assert.AreEqual("capsulesCST", v.Value);
+                    });
+            Property.Parse("CST-100 capsule = capsulesCST")
+                    .WillSucceed(v =>
+                    {
+                        Assert.AreEqual("CST-100 capsule", v.Name);
+                        Assert.AreEqual("capsulesCST", v.Value);
+                    });
+            Property.Parse("Castor-120/Regressive = 0,SolidsTVC")
+                    .WillSucceed(v =>
+                    {
+                        Assert.AreEqual("Castor-120/Regressive", v.Name);
+                        Assert.AreEqual("0,SolidsTVC", v.Value);
+                    });
+            Property.Parse("Castor-120/Saddle = 0,SolidsTVC")
+                    .WillSucceed(v =>
+                    {
+                        Assert.AreEqual("Castor-120/Saddle", v.Name);
+                        Assert.AreEqual("0,SolidsTVC", v.Value);
+                    });
+        }
+
+        [Test]
         public void PropertyParse_NeedsClause_works()
         {
             Property.Parse("key:NEEDS[Astrogator|PlanningNode&SmartTank] = value")


### PR DESCRIPTION
## Problem

Now the KSP-RO folks are hitting false positives in RP-0:

https://github.com/KSP-RO/RP-0/runs/6228199607?check_suite_focus=true

![image](https://user-images.githubusercontent.com/1559108/165990826-1232c88b-73a9-4885-a62e-dcf63b34c6eb.png)

## Cause

These lines use spaces and slashes in property identifiers, which we haven't handled yet because spaces are used to separate identifiers, operators, and values, and slashes are part of node paths.

## Changes

Now property identifiers allow slashes and spaces, but they still have to start and end with a non-space.

This introduces ambiguity with operators:

```
a += b
```

Is this `a plusequals b` or `(a +) equals b`? To resolve this in favor of the arithmetic assignment operators, we use a lookahead for the arithmetic operator characters to reject them when they're before an equals.

Tests are added and some duplicated code is refactored into a `PropertyValue` parser.

With these changes, all of the RP-0 files pass validation as they are.