### PR TITLE
Fix parsing of comment containing equals

### DIFF
--- a/KSPMMCfgParser/Parser.Property.cs
+++ b/KSPMMCfgParser/Parser.Property.cs
@@ -145,8 +145,10 @@ namespace KSPMMCfgParser
         /// </summary>
         private static readonly Parser<char, char> PropertyWordChar =
             LetterOrDigit() | OneOf("#_.?")
-                            // Only allow these if they're not part of += -= *= /=
-                            | OneOf("+-*/").Left(LookAhead(Not(Char('='))));
+                            // Only allow these if they're not part of += -= *=
+                            | OneOf("+-*").Left(LookAhead(Not(Char('='))))
+                            // Only allow / if it's not part of /= //
+                            | Char('/').Left(LookAhead(NoneOf("=/")));
 
         /// <summary>
         /// Section of a property identifier containing spaces, always ends in a non-space

--- a/Tests/Parser.ConfigNode.cs
+++ b/Tests/Parser.ConfigNode.cs
@@ -353,5 +353,24 @@ namespace Tests
             });
         }
 
+        [Test]
+        public void ConfigFileParse_CommentWithEquals_IsNode()
+        {
+            ConfigFile.ToArray().Parse(@"
+                CONFIG
+                {
+                    PROPELLANT // Ratio = 3.55 [1]
+                    {
+                        name = LqdMethane
+                        ratio = 0.43
+                        DrawGauge = true
+                    }
+                }
+            ").WillSucceed(v =>
+            {
+                Assert.AreEqual(1, v[0].Children.Length);
+            });
+        }
+
     }
 }


### PR DESCRIPTION
## Problem

https://github.com/KSP-RO/RealismOverhaul/runs/6237066103?check_suite_focus=true

![image](https://user-images.githubusercontent.com/1559108/166087052-8d6df2ac-9ce4-41e3-a728-d91a7794ef5f.png)

```
		CONFIG
		{
			name = Raptor //[6]
			specLevel = prototype
			maxThrust = 1650
			minThrust = 660 // 40% throttle [3]
			heatProduction = 100
			PROPELLANT // Ratio = 3.55 [1]
			{
				name = LqdMethane
				ratio = 0.43
				DrawGauge = true
			}
```

## Cause

As of #6, this line is parsed as a property:

```
			PROPELLANT // Ratio = 3.55 [1]
```

The property identifier is `PROPELLANT // Ratio` and the value is `3.55 [1]`. Then on the next line it finds a `{` without a node identifier.

## Changes

Now the property identifier excludes comments with a lookahead, so `PROPELLANT` will be parsed as a node identifier again. The above text is added to a test.
