### PR TITLE
Tidy up GitHub workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build parser
+name: Build parser and validator
 
 on:
   push:
@@ -12,11 +12,9 @@ on:
 
 jobs:
   build:
+    name: Build and test
     runs-on: ubuntu-latest
-
-    container:
-      image: mono:latest
-
+    container: mono:latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -32,6 +30,7 @@ jobs:
           cp _build/KSPMMCfgValidator/Debug/bin/net461/KSPMMCfgValidator.exe .
           chmod a+x KSPMMCfgValidator.exe
           mono ./KSPMMCfgValidator.exe
+
       - name: Upload parser nupkg artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,9 @@ on:
 
 jobs:
   release:
+    name: Build release and publish assets
     runs-on: ubuntu-latest
-
-    container:
-      image: mono:latest
-
+    container: mono:latest
     steps:
       - name: Installing build dependencies
         run: apt-get update && apt-get install -y wget jq
@@ -24,14 +22,14 @@ jobs:
           cp _build/KSPMMCfgValidator/Release/bin/net461/KSPMMCfgValidator.exe .
           chmod a+x KSPMMCfgValidator.exe
           mono ./KSPMMCfgValidator.exe
+
       - name: Get release data
         id: release_data
         run: |
           echo -n '::set-output name=upload_url::'
-          wget -qO- https://api.github.com/repos/$GITHUB_REPOSITORY/releases/latest | jq -rM '.upload_url'
+          curl -fsSL https://api.github.com/repos/$GITHUB_REPOSITORY/releases/latest | jq -rM '.upload_url'
           echo -n '::set-output name=nupkg_basename::'
           basename _build/KSPMMCfgParser/Release/bin/KSPMMCfgParser.*.nupkg
-
       - name: Upload parser nupkg release asset
         uses: actions/upload-release-asset@v1.0.1
         env:
@@ -55,7 +53,7 @@ jobs:
       - name: Publish parser to NuGet
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        if: ${{ env.NUGET_API_KEY }}
+        if: env.NUGET_API_KEY
         run: |
           curl -o nuget.exe -L 'https://dist.nuget.org/win-x86-commandline/v5.6.0/nuget.exe'
           mono nuget.exe push _build/KSPMMCfgParser/Release/bin/${{ steps.release_data.outputs.nupkg_basename }} ${{ secrets.NUGET_API_KEY }} -Source https://api.nuget.org/v3/index.json -SkipDuplicate
@@ -64,7 +62,7 @@ jobs:
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-        if: ${{ env.DOCKERHUB_USERNAME && env.DOCKERHUB_PASSWORD }}
+        if: env.DOCKERHUB_USERNAME && env.DOCKERHUB_PASSWORD
         run: |
           curl -fsSL https://get.docker.com -o get-docker.sh
           sh get-docker.sh


### PR DESCRIPTION
## Motivation

I reviewed the documentation for GitHub Actions hoping that I could split our workflows into separate "build" and "publish" jobs:

https://docs.github.com/en/actions/learn-github-actions

Unfortunately jobs can't share files without uploading and downloading artifacts (see github/feedback#5379), and the point was to remove the "upload artifact" step from the build job.

However, there were still a few things I found that could be tidied up.

## Changes

- The jobs now have `name`s
- "[When you only specify a container image, you can omit the image keyword](https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container#example-running-a-job-within-a-container)"
- Both `wget` and `curl` were used in different places, now we use `curl` everywhere for consistency
- "[When you use expressions in an if conditional, you may omit the expression syntax (`${{ }}`) because GitHub automatically evaluates the if conditional as an expression](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution#overview)"