### PR TITLE
Build package with nuspec file for readme support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     container: mono:latest
     steps:
+      - name: Installing build dependencies
+        run: nuget update -self
       - name: Checkout
         uses: actions/checkout@v2
       - name: Restore cache for ~/.nuget/packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     container: mono:latest
     steps:
       - name: Installing build dependencies
-        run: apt-get update && apt-get install -y wget jq
+        run: apt-get update && apt-get install -y jq
       - name: Checkout
         uses: actions/checkout@v2
       - name: Restore, build, and test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,9 @@ jobs:
     container: mono:latest
     steps:
       - name: Installing build dependencies
-        run: apt-get update && apt-get install -y jq
+        run: |
+          apt-get update && apt-get install -y jq
+          nuget update -self
       - name: Checkout
         uses: actions/checkout@v2
       - name: Restore, build, and test

--- a/KSPMMCfgParser/KSPMMCfgParser.csproj
+++ b/KSPMMCfgParser/KSPMMCfgParser.csproj
@@ -26,21 +26,10 @@
     <DocumentationFile>$(BaseIntermediateOutputPath)$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageId>KSPMMCfgParser</PackageId>
-    <Title>Kerbal Space Program Module Manager Config File Parser</Title>
-    <Description>Parses .cfg files in combined KSP/MM format</Description>
-    <Version>1.0.6</Version>
-    <PackageVersion>1.0.6</PackageVersion>
-    <Authors>The CKAN Authors</Authors>
-    <Copyright>Copyright © CKAN Authors 2022</Copyright>
-    <PackageTags>KerbalSpaceProgram ModuleManager Parser</PackageTags>
+    <NuspecFile>KSPMMCfgParser.nuspec</NuspecFile>
+    <NuspecProperties>OutputPath=$(OutputPath);TargetFramework=$(TargetFramework)</NuspecProperties>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IsPackable>true</IsPackable>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageProjectUrl>https://github.com/KSP-CKAN/KSPMMCfgParser</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/KSP-CKAN/KSPMMCfgParser</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/KSPMMCfgParser/KSPMMCfgParser.nuspec
+++ b/KSPMMCfgParser/KSPMMCfgParser.nuspec
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>KSPMMCfgParser</id>
+    <version>1.0.6</version>
+    <title>Kerbal Space Program Module Manager Config File Parser</title>
+    <authors>The CKAN Authors</authors>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <readme>README.md</readme>
+    <projectUrl>https://github.com/KSP-CKAN/KSPMMCfgParser</projectUrl>
+    <description>Parses .cfg files in combined KSP/MM format</description>
+    <copyright>Copyright © CKAN Authors 2022</copyright>
+    <tags>KerbalSpaceProgram ModuleManager Parser</tags>
+    <repository type="git"
+                url="https://github.com/KSP-CKAN/KSPMMCfgParser" />
+    <dependencies>
+      <group targetFramework=".NETFramework4.6.1">
+        <dependency id="log4net"
+                    version="2.0.10"
+                    exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="Microsoft.CSharp"
+                         targetFramework=".NETFramework4.6.1" />
+      <frameworkAssembly assemblyName="System"
+                         targetFramework=".NETFramework4.6.1" />
+      <frameworkAssembly assemblyName="System.Transactions"
+                         targetFramework=".NETFramework4.6.1" />
+    </frameworkAssemblies>
+  </metadata>
+  <files>
+    <file src="$OutputPath$$TargetFramework$\KSPMMCfgParser.*"
+          target="lib\$TargetFramework$" />
+    <file src="..\README.md"
+          target="\" />
+  </files>
+</package>


### PR DESCRIPTION
## Problem

The Nuget package page isn't showing our README:

https://www.nuget.org/packages/KSPMMCfgParser/

![image](https://user-images.githubusercontent.com/1559108/167189925-4f5c57ad-979b-4f05-ae69-32474b88cb5c.png)



## Causes

- We set `PackageReadmeFile` in our `.csproj` file as we're supposed to
  https://docs.microsoft.com/en-us/nuget/nuget-org/package-readme-on-nuget-org
- But that property requires ... tools we're not using? to work
- So our `.nupkg` file's `.nuspec` file doesn't contain the `readme` property that it should

## Changes

Now our package properties are moved out of the `.csproj` and into a new `.nuspec` file based on the one that was previously autogenerated, except with a `readme` property. The `NuspecFile` property is added to the `.csproj` to make it use the new file for packing.

We can test this by checking that the `.nupkg` asset (which is just a ZIP file) generated for this pull request contains a `readme` property in its `.nuspec` file.

Also the release workflow no longer installs `wget` since it is no longer needed after #8.
