### PR TITLE
Add support for wildcards in NodeIdentifier

### DIFF
--- a/KSPMMCfgParser/Parser.ConfigNode.cs
+++ b/KSPMMCfgParser/Parser.ConfigNode.cs
@@ -210,7 +210,7 @@ namespace KSPMMCfgParser
         /// <summary>
         /// Parser matching a name that may contain wildcards
         /// </summary>
-        public static readonly Parser<char, string> NodeIdentifier = Many1(OneOf("-_.+")
+        public static readonly Parser<char, string> NodeIdentifier = Many1(OneOf("-_.+*?")
                                                                            | LetterOrDigit()).AsString();
 
         /// <summary>

--- a/Tests/Parser.ConfigNode.cs
+++ b/Tests/Parser.ConfigNode.cs
@@ -372,5 +372,23 @@ namespace Tests
             });
         }
 
+        [Test]
+        public void ConfigFileParse_WildCardInNodeName_Works()
+        {
+            ConfigFile.ToArray().Parse(@"
+                @*,*
+                {
+                    !#autoLOC_439627 = Active Programs: <<1>> [Max: <<2>>]
+                }
+                @?ot?ase?ensitive // (n|N)ot(c|C)ase(s|S)ensitive
+                {
+                }
+            ").WillSucceed(v =>
+            {
+                Assert.AreEqual("*", v[0].Name, "node name with '*'");
+                Assert.AreEqual("?ot?ase?ensitive", v[1].Name, "node name with '?'");
+            });
+        }
+
     }
 }


### PR DESCRIPTION
As of MM v4.2.2 node names can contain wildcards.

Adds support for wildcards in node names and a test to cover the new functionality.

Fixes #14 