### PR TITLE
Switch workflows from set-output to $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,10 @@ jobs:
       - name: Get release data
         id: release_data
         run: |
-          echo -n '::set-output name=upload_url::'
-          curl -fsSL https://api.github.com/repos/$GITHUB_REPOSITORY/releases/latest | jq -rM '.upload_url'
-          echo -n '::set-output name=nupkg_basename::'
-          basename _build/KSPMMCfgParser/Release/bin/KSPMMCfgParser.*.nupkg
+          echo -n 'upload_url=' >> $GITHUB_OUTPUT
+          curl -fsSL https://api.github.com/repos/$GITHUB_REPOSITORY/releases/latest | jq -rM '.upload_url' >> $GITHUB_OUTPUT
+          echo -n 'nupkg_basename=' >> $GITHUB_OUTPUT
+          basename _build/KSPMMCfgParser/Release/bin/KSPMMCfgParser.*.nupkg >> $GITHUB_OUTPUT
       - name: Upload parser nupkg release asset
         uses: actions/upload-release-asset@v1.0.1
         env:


### PR DESCRIPTION
## Motivation

Originally, the documented way to pass info from one GitHub workflow step to the next was to print this to stdout:

```
::set-output name=param_name::param_value
```

We used this in KSPMMCfgParser's workflows to capture the release upload URL and the package basename.

Recently GitHub decided they didn't like that anymore and added a warning message for it:

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

The replacement is to append `param_name=param_value` lines to the file specified by `$GITHUB_OUTPUT`:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

We have until June 2023 to migrate.

Noted thanks to KSP-CKAN/KSPMMCfgParser#16.

## Changes

Now the prescribed migration is done for the KSPMMCfgParser repo.

I'll self-review this.
