### PR TITLE
Fix netstandard runtime error by installing mono-devel

### DIFF
--- a/KSPMMCfgParser/KSPMMCfgParser.csproj
+++ b/KSPMMCfgParser/KSPMMCfgParser.csproj
@@ -46,7 +46,6 @@
     <Reference Include="System.Transactions" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="ParsecSharp" Version="3.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/KSPMMCfgValidator/Dockerfile
+++ b/KSPMMCfgValidator/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
 
 # Install the necessary pieces of Mono
 RUN apt-get install -y --no-install-recommends \
-    mono-runtime ca-certificates-mono libmono-microsoft-csharp4.0-cil libmono-system-data4.0-cil libmono-system-runtime-serialization4.0-cil libmono-system-transactions4.0-cil libmono-system-net-http-webrequest4.0-cil
+    mono-runtime ca-certificates-mono mono-devel mono-roslyn
 
 ADD KSPMMCfgValidator.exe /usr/local/bin/.
 ENTRYPOINT ["mono", "/usr/local/bin/KSPMMCfgValidator.exe"]


### PR DESCRIPTION
## Problem

```
# mono /usr/local/bin/KSPMMCfgValidator.exe

Unhandled Exception:
System.TypeInitializationException: The type initializer for 'KSPMMCfgValidator.KSPMMCfgValidator' threw an exception. ---> System.BadImageFormatException: Could not resolve field token 0x0400000a, due to: Could not load type of field 'KSPMMCfgValidator.KSPMMCfgValidator+<>c:<>9__1_1' (1) due to: Could not load file or assembly 'netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies. assembly:/usr/local/bin/KSPMMCfgValidator.exe type:<>c member:(null)
   --- End of inner exception stack trace ---
[ERROR] FATAL UNHANDLED EXCEPTION: System.TypeInitializationException: The type initializer for 'KSPMMCfgValidator.KSPMMCfgValidator' threw an exception. ---> System.BadImageFormatException: Could not resolve field token 0x0400000a, due to: Could not load type of field 'KSPMMCfgValidator.KSPMMCfgValidator+<>c:<>9__1_1' (1) due to: Could not load file or assembly 'netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies. assembly:/usr/local/bin/KSPMMCfgValidator.exe type:<>c member:(null)
   --- End of inner exception stack trace ---
```

## Cause

Mysteries of .NET and Mono. The core error message `Could not load file or assembly 'netstandard, Version=2.0.0.0` is essentially completely meaningless in terms of pointing toward a specific problem, so we have to fall back to trial and error.

Installing `mono-complete` fixed it, so I dug into its dependencies, and found that if I installed all of them except for `mono-devel` and `mono-roslyn`, the problem still happened, but if I installed those two packages, it was fixed. This should not happen; dev/compiler tools should not be needed to run an app that's already compiled, but that's where the evidence is leading us.

## Changes

Now the Dockerfile installs `mono-devel` and `mono-roslyn`, which unfortunately pulls in most of the Mono cruft we were trying to trim in #18. But there appears to be no other way to get Mono to work here.

```
REPOSITORY                         TAG       IMAGE ID       CREATED             SIZE
kspckan/kspmmcfgvalidator          latest    b235ab1106a1   20 hours ago        197MB
cfgvalidator_test                  latest    ddda9bf1fa99   57 seconds ago      541MB
```

Fixes #19.
